### PR TITLE
Seams toggle and some css animation

### DIFF
--- a/host/src/components/remote-ssr.tsx
+++ b/host/src/components/remote-ssr.tsx
@@ -9,6 +9,7 @@ export interface Props {
 export default component$(({ name, path }: Props) => {
 	return (
 		<div class='remote-component'>
+			<p class="remote-label">{path}</p>
 			<SSRStream>
 				{async (stream) => {
 					const res = await fetch(path);

--- a/host/src/global.css
+++ b/host/src/global.css
@@ -1,0 +1,25 @@
+.remote-component {
+  position: relative;
+  outline: 2px dashed transparent;
+}
+
+[data-seams=""]>.remote-component {
+  outline-color: purple;
+}
+
+.remote-component>.remote-label {
+  position: absolute;
+  opacity: 0;
+  top: 0;
+  right: 0;
+  z-index: 99;
+  padding: .5rem;
+  pointer-events: none;
+  background-color: black;
+  color: white;
+  transition: opacity 200ms linear;
+}
+
+[data-seams=""]>.remote-component>.remote-label {
+  opacity: 1;
+}

--- a/host/src/routes/layout.tsx
+++ b/host/src/routes/layout.tsx
@@ -2,18 +2,19 @@ import {
 	component$,
 	Slot,
 	useContextProvider,
-	useStore,
+	useStore
 } from '@builder.io/qwik';
 import { AppState, GlobalAppState } from './constants';
 
 export default component$(() => {
 	const store = useStore<AppState>({
-		showSeams: false,
+		showSeams: true,
 	});
 	useContextProvider(GlobalAppState, store);
 	return (
 		<main data-seams={store.showSeams}>
 			<Slot />
+			<button onClick$={() => store.showSeams = !store.showSeams}>Show Seams</button>
 		</main>
 	);
 });

--- a/host/src/routes/layout.tsx
+++ b/host/src/routes/layout.tsx
@@ -14,7 +14,9 @@ export default component$(() => {
 	return (
 		<main data-seams={store.showSeams}>
 			<Slot />
-			<button onClick$={() => store.showSeams = !store.showSeams}>Show Seams</button>
+			<footer>
+				<button onClick$={() => store.showSeams = !store.showSeams}>Show Seams</button>
+			</footer>
 		</main>
 	);
 });


### PR DESCRIPTION
Adds a toggle button to show the seams and orgins for each Microfrontend Component. Will be needed for when Misko reveals the Microfrontend architecture. Also has  simple fade-in for effect for a little razzle-dazzle.

Note: The button is unstyled at the moment. That's because we will probably add another microfrontend for the footer, and it can be styled there. It will also be a good, simple way to test communication between the host page and a microfrontend component.