### PR TITLE
fix/improve usage of main element

### DIFF
--- a/apps/hero/src/routes/layout.tsx
+++ b/apps/hero/src/routes/layout.tsx
@@ -1,11 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
 
 export default component$(() => {
-	return (
-		<>
-			<main>
-				<Slot />
-			</main>
-		</>
-	);
+	return <Slot />;
 });

--- a/apps/host/src/routes/index.tsx
+++ b/apps/host/src/routes/index.tsx
@@ -8,10 +8,12 @@ export default component$(() => {
 	return (
 		<>
 			<RemoteSsr remote={remotes.menu} />
-			<RemoteSsr remote={remotes.cart} />
-			<RemoteSsr remote={remotes.hero} />
-			<RemoteSsr remote={remotes.product} />
-			<Reviews />
+			<main>
+				<RemoteSsr remote={remotes.cart} />
+				<RemoteSsr remote={remotes.hero} />
+				<RemoteSsr remote={remotes.product} />
+				<Reviews />
+			</main>
 		</>
 	);
 });

--- a/apps/host/src/routes/layout.tsx
+++ b/apps/host/src/routes/layout.tsx
@@ -2,7 +2,7 @@ import {
 	component$,
 	Slot,
 	useContextProvider,
-	useStore,
+	useStore
 } from '@builder.io/qwik';
 import { AppState, GlobalAppState } from '../store';
 
@@ -12,11 +12,11 @@ export default component$(() => {
 	});
 	useContextProvider(GlobalAppState, store);
 	return (
-		<main data-seams={store.showSeams}>
+		<div data-seams={store.showSeams}>
 			<button onClick$={() => (store.showSeams = !store.showSeams)}>
 				Show Seams
 			</button>
 			<Slot />
-		</main>
+		</div>
 	);
 });

--- a/apps/menu/src/routes/layout.tsx
+++ b/apps/menu/src/routes/layout.tsx
@@ -1,11 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
 
 export default component$(() => {
-	return (
-		<>
-			<main>
-				<Slot />
-			</main>
-		</>
-	);
+	return <Slot />;
 });

--- a/apps/product/src/routes/layout.tsx
+++ b/apps/product/src/routes/layout.tsx
@@ -1,11 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
 
 export default component$(() => {
-	return (
-		<>
-			<main>
-				<Slot />
-			</main>
-		</>
-	);
+	return <Slot />;
 });

--- a/apps/reviews/src/routes/layout.tsx
+++ b/apps/reviews/src/routes/layout.tsx
@@ -1,11 +1,5 @@
 import { component$, Slot } from '@builder.io/qwik';
 
 export default component$(() => {
-	return (
-		<>
-			<main>
-				<Slot />
-			</main>
-		</>
-	);
+	return <Slot />;
 });


### PR DESCRIPTION
I appreciate that this is not that important and people might not care...

but anyways a page should always have only a single `main` element and that element should contain the main content of the page (i.e. no header, menu, etc...)

(see: [use-only-one-main-on-a-pagel](https://adrianroselli.com/2015/09/use-only-one-main-on-a-page.html))

## before
![Screenshot at 2022-12-04 17-15-40](https://user-images.githubusercontent.com/61631103/205505741-503d28b6-6632-40aa-9260-7186d853a5ce.png)

## after
![Screenshot at 2022-12-04 17-18-07](https://user-images.githubusercontent.com/61631103/205505753-4f482b80-2fdd-462b-82c1-966250fdf7fb.png)
