### PR TITLE
chore: set the supported node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "qwik-dream-demo",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
   "description": "Qwik dream demo",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Cannot run the app with older versions of node, getting the error `TypeError: (intermediate value).body.getReader is not a function`, switching to node 18 resolves the issue, so it's reasonable to add a restriction 
![image](https://user-images.githubusercontent.com/33101123/206123693-8f4b79a2-07a2-4f89-8bd1-e8adaff32ca0.png)
