### PR TITLE
fix remote-labels clickable when invisible

### DIFF
--- a/apps/host/src/global.css
+++ b/apps/host/src/global.css
@@ -11,6 +11,7 @@
 }
 
 .remote-component>.remote-label {
+  display: none;
   position: absolute;
   opacity: 0;
   top: 0;
@@ -22,7 +23,6 @@
   background-color: #fff;
   color: var(--seams-color);
   outline: 1px solid currentColor;
-  transition: opacity 200ms linear;
   cursor: pointer;
 }
 
@@ -31,5 +31,13 @@
 }
 
 [data-seams]>main>.remote-component>.remote-label {
+  display: block;
   opacity: 1;
+  animation: remoteLabelFadeIn 200ms linear forwards;
+}
+
+@keyframes remoteLabelFadeIn {
+  0% { opacity: 0; display: none; }
+  1% { opacity: 0; display: block; }
+  100% { opacity: 1; display: block; }
 }


### PR DESCRIPTION
The seams labels can still clicked even if they are invisible:
![Peek 2022-12-15 00-44](https://user-images.githubusercontent.com/61631103/207746009-a9233e2c-db67-42ab-96bf-430de508b703.gif)

This is my bad, I didn't notice this issue when I made them clickable :sweat: 
